### PR TITLE
Use intermediate file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM hashicorp/terraform:1.0.6
+ARG TERRAFORM_VERSION=1.0.6
+FROM hashicorp/terraform:${TERRAFORM_VERSION}
 
 LABEL repository="https://github.com/robburger/terraform-pr-commenter" \
       homepage="https://github.com/robburger/terraform-pr-commenter" \

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
       name: Write terraform output to file
     - run: cp "${{ github.event_path }}" event.json
       shell: bash
-      name: Write terraform output to file
+      name: Copy event json to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,7 @@ runs:
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT \
         -e COMMENTER_INPUT \
+        -v "$(pwd)"/tfplan:/tfplan \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
-    - run: docker run -v commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
+    - run: docker run commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
 

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
-        -e GITHUB_EVENT=${{ github.event }}
+        -e GITHUB_EVENT=${{ toJSON(github.event) }}
         commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: echo '${{ inputs.commenter_input }}' >> tf.out
+    - run: echo -e '${{ inputs.commenter_input }}' > tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,6 @@ runs:
         # must enumerate all env vars we want to pass into docker, sadly.
         docker run \
         -e GITHUB_TOKEN \
-        -e GITHUB_EVENT_PATH \
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \

--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,11 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: printf "%s\n" "${{ inputs.commenter_input }}" > tf.out
+    - run: printf "%s\n" "$INPUT" > tf.out
       shell: bash
       name: Write terraform output to file
+      env:
+        INPUT: ${{ inputs.commenter_input }}
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
@@ -39,4 +41,5 @@ runs:
         commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
+
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Build commenter docker image
-      run: docker build -t --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
+      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
     - name: Run commenter image (plan)
       env:

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: echo ${{ inputs.commenter_input }} >> tf.out
+    - run: echo "${{ inputs.commenter_input }}" >> tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: echo -e '${{ inputs.commenter_input }}' > tf.out
+    - run: echo -E '${{ inputs.commenter_input }}' > tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,12 @@ inputs:
     description: 'The exit code from a previous step output'
     required: true
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
-  args:
-    - ${{ inputs.commenter_type }}
-    - ${{ inputs.commenter_input }}
-    - ${{ inputs.commenter_exitcode }}
+  using: "composite"
+  steps:
+    - run: echo ${{ inputs.commenter_input }} >> tf.out
+    - uses: 'docker'
+      image: 'Dockerfile'
+      args:
+       - ${{ inputs.commenter_type }}
+       - tf.out
+       - ${{ inputs.commenter_exitcode }}

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
-        -e GITHUB_EVENT='${{ toJSON(github.event) }}'
+        -e GITHUB_EVENT='${{ toJSON(github.event) }}' \
         commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: echo -E '${{ inputs.commenter_input }}' > tf.out
+    - run: printf "%s "${{ inputs.commenter_input }}" > tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
-        -e GITHUB_EVENT=${{ toJSON(github.event) }}
+        -e GITHUB_EVENT='${{ toJSON(github.event) }}'
         commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         -e GITHUB_EVENT \
         -e COMMENTER_INPUT \
         -e AWS_ACCESS_KEY_ID \
-        -e AWS_SECRET_ACCESS_KEY \
+        -e AWS_SECRET_KEY \
         -e AWS_REGION \
         -v "$(pwd)"/:/workspace \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: printf "%s\n" '${{ inputs.commenter_input }}' > tf.out
+    - run: printf "%s\n" "${{ inputs.commenter_input }}" > tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,8 @@ runs:
   steps:
     - run: echo ${{ inputs.commenter_input }} >> tf.out
       shell: bash
-    - uses: 'docker'
-      with:
-        image: 'Dockerfile'
-        args:
-         - ${{ inputs.commenter_type }}
-         - tf.out
-         - ${{ inputs.commenter_exitcode }}
+    - run: docker build -t commenter -f Dockerfile
+      shell: bash
+    - run: docker run -it -v local ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
+      shell: bash
+

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
   steps:
     - run: echo ${{ inputs.commenter_input }} >> tf.out
       shell: bash
-    - run: docker build -t commenter -f Dockerfile
+    - run: docker build -t commenter -f Dockerfile .
       shell: bash
     - run: docker run -it -v local ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -17,16 +17,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-#    - name: Pull
-#      uses: actions/checkout@v2
-#      with:
-#        ref: ${{ github.event.deployment.ref }}
-#        lfs: true
-    - run: printf "%s\n" "$INPUT" > tf.out
-      shell: bash
-      name: Write terraform output to file
-      env:
-        INPUT: ${{ inputs.commenter_input }}
+#    - run: printf "%s\n" "$INPUT" > tf.out
+#      shell: bash
+#      name: Write terraform output to file
+#      env:
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
@@ -38,8 +32,11 @@ runs:
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT='${{ toJSON(github.event) }}' \
-        commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
+        -e COMMENTER_INPUT
+        commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
+      env:
+        COMMENTER_INPUT: ${{ inputs.commenter_input }}
 
 

--- a/action.yml
+++ b/action.yml
@@ -25,9 +25,6 @@ runs:
     - run: echo '${{ inputs.commenter_input }}' >> tf.out
       shell: bash
       name: Write terraform output to file
-    - run: cp '${{ github.event_path }}' event.json
-      shell: bash
-      name: Copy event json to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
@@ -38,6 +35,7 @@ runs:
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
+        -e GITHUB_EVENT=${{ github.event }}
         commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,15 @@ runs:
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
-    - run: docker run commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
+    - run: |
+        # must enumerate all env vars we want to pass into docker, sadly.
+        docker run \
+        -e GITHUB_TOKEN \
+        -e GITHUB_EVENT_PATH \
+        -e TF_WORKSPACE \
+        -e EXPAND_SUMMARY_DETAILS \
+        -e HIGHLIGHT_CHANGES \
+        commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT \
         -e COMMENTER_INPUT \
-        -v "$(pwd)"/tfplan:/tfplan \
+        -v "$(pwd)"/:/workspace \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       if: ${{ inputs.commenter_type == 'plan' }}

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,7 @@ runs:
       env:
         COMMENTER_INPUT: ${{ inputs.commenter_input }}
         GITHUB_EVENT: ${{ toJSON(github.event) }}
+        AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_KEY }}
       run: |
         docker run \
         -e GITHUB_TOKEN \
@@ -38,6 +39,7 @@ runs:
         -e COMMENTER_INPUT \
         -e AWS_ACCESS_KEY_ID \
         -e AWS_SECRET_KEY \
+        -e AWS_SECRET_ACCESS_KEY \
         -e AWS_REGION \
         -v "$(pwd)"/:/workspace \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
@@ -55,9 +57,6 @@ runs:
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT \
         -e COMMENTER_INPUT \
-        -e AWS_ACCESS_KEY_ID \
-        -e AWS_SECRET_ACCESS_KEY \
-        -e AWS_REGION \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       if: ${{ inputs.commenter_type != 'plan' }}

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
-    - run: docker run -it -v local ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
+    - run: docker run -it -v commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
 

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - run: echo "${{ inputs.commenter_input }}" >> tf.out
       shell: bash
       name: Write terraform output to file
-    - run: cp ${{ github.event_path }} event.json
+    - run: cp "${{ github.event_path }}" event.json
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT \
-        -e COMMENTER_INPUT
+        -e COMMENTER_INPUT \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,6 @@ runs:
         GITHUB_EVENT: ${{ toJSON(github.event) }}
       run: |
         docker run \
-        # must enumerate all env vars we want to pass into docker, sadly. \
         -e GITHUB_TOKEN \
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
@@ -43,7 +42,6 @@ runs:
         GITHUB_EVENT: ${{ toJSON(github.event) }}
       run: |
         docker run \
-        # must enumerate all env vars we want to pass into docker, sadly. \
         -e GITHUB_TOKEN \
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \

--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,15 @@ inputs:
   commenter_exitcode:
     description: 'The exit code from a previous step output'
     required: true
+  terraform_version:
+    description: 'The version of terraform with which a plan was generated'
+    required: false
+    default: "1.0.6"
 runs:
   using: "composite"
   steps:
     - name: Build commenter docker image
-      run: docker build -t --build-arg TERRAFORM_VERSION=$TF_VERSION commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
+      run: docker build -t --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
     - name: Run commenter image (plan)
       env:

--- a/action.yml
+++ b/action.yml
@@ -18,9 +18,11 @@ runs:
   using: "composite"
   steps:
     - run: echo ${{ inputs.commenter_input }} >> tf.out
+      shell: bash
     - uses: 'docker'
-      image: 'Dockerfile'
-      args:
-       - ${{ inputs.commenter_type }}
-       - tf.out
-       - ${{ inputs.commenter_exitcode }}
+      with:
+        image: 'Dockerfile'
+        args:
+         - ${{ inputs.commenter_type }}
+         - tf.out
+         - ${{ inputs.commenter_exitcode }}

--- a/action.yml
+++ b/action.yml
@@ -17,18 +17,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Pull
-      uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.deployment.ref }}
-        lfs: true
+#    - name: Pull
+#      uses: actions/checkout@v2
+#      with:
+#        ref: ${{ github.event.deployment.ref }}
+#        lfs: true
     - run: echo ${{ inputs.commenter_input }} >> tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
-    - run: docker run -it -v commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
+    - run: docker run -v commenter ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
         -v "$(pwd)"/tfplan:/tfplan \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
-      if: ${{ inputs.commenter_type == "plan" }}
+      if: ${{ inputs.commenter_type == 'plan' }}
     - name: Run commenter image (non-plan)
       env:
         COMMENTER_INPUT: ${{ inputs.commenter_input }}
@@ -52,5 +52,5 @@ runs:
         -e COMMENTER_INPUT \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
-      if: ${{ inputs.commenter_type != "plan" }}
+      if: ${{ inputs.commenter_type != 'plan' }}
 

--- a/action.yml
+++ b/action.yml
@@ -31,12 +31,13 @@ runs:
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
         -e HIGHLIGHT_CHANGES \
-        -e GITHUB_EVENT='${{ toJSON(github.event) }}' \
+        -e GITHUB_EVENT \
         -e COMMENTER_INPUT
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       name: Run commenter image
       env:
         COMMENTER_INPUT: ${{ inputs.commenter_input }}
+        GITHUB_EVENT: ${{ toJSON(github.event) }}
 
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: printf "%s" "${{ inputs.commenter_input }}" > tf.out
+    - run: printf "%s\n" '${{ inputs.commenter_input }}' > tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: printf "%s "${{ inputs.commenter_input }}" > tf.out
+    - run: printf "%s" "${{ inputs.commenter_input }}" > tf.out
       shell: bash
       name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -17,10 +17,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Pull
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.deployment.ref }}
+        lfs: true
     - run: echo ${{ inputs.commenter_input }} >> tf.out
       shell: bash
+      name: Write terraform output to file
     - run: docker build -t commenter -f Dockerfile .
       shell: bash
+      name: Build commenter docker image
     - run: docker run -it -v local ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}
       shell: bash
+      name: Run commenter image
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,9 @@ runs:
     - run: echo "${{ inputs.commenter_input }}" >> tf.out
       shell: bash
       name: Write terraform output to file
+    - run: cp ${{ github.event_path }} event.json
+      shell: bash
+      name: Write terraform output to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image

--- a/action.yml
+++ b/action.yml
@@ -17,12 +17,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
+    - name: Build commenter docker image
+      run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
-      name: Build commenter docker image
-    - run: |
-        # must enumerate all env vars we want to pass into docker, sadly.
+    - name: Run commenter image (plan)
+      env:
+        COMMENTER_INPUT: ${{ inputs.commenter_input }}
+        GITHUB_EVENT: ${{ toJSON(github.event) }}
+      run: |
         docker run \
+        # must enumerate all env vars we want to pass into docker, sadly. \
         -e GITHUB_TOKEN \
         -e TF_WORKSPACE \
         -e EXPAND_SUMMARY_DETAILS \
@@ -32,9 +36,21 @@ runs:
         -v "$(pwd)"/tfplan:/tfplan \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
-      name: Run commenter image
+      if: ${{ inputs.commenter_type == "plan" }}
+    - name: Run commenter image (non-plan)
       env:
         COMMENTER_INPUT: ${{ inputs.commenter_input }}
         GITHUB_EVENT: ${{ toJSON(github.event) }}
-
+      run: |
+        docker run \
+        # must enumerate all env vars we want to pass into docker, sadly. \
+        -e GITHUB_TOKEN \
+        -e TF_WORKSPACE \
+        -e EXPAND_SUMMARY_DETAILS \
+        -e HIGHLIGHT_CHANGES \
+        -e GITHUB_EVENT \
+        -e COMMENTER_INPUT \
+        commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
+      shell: bash
+      if: ${{ inputs.commenter_type != "plan" }}
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'The type of comment. Options: [fmt, init, plan]'
     required: true
   commenter_input:
-    description: 'The comment to post from a previous step output'
+    description: 'The comment to post from a previous step output or a tfplan file'
     required: true
   commenter_exitcode:
     description: 'The exit code from a previous step output'
@@ -17,10 +17,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-#    - run: printf "%s\n" "$INPUT" > tf.out
-#      shell: bash
-#      name: Write terraform output to file
-#      env:
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Build commenter docker image
-      run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
+      run: docker build -t --build-arg TERRAFORM_VERSION=$TF_VERSION commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
     - name: Run commenter image (plan)
       env:

--- a/action.yml
+++ b/action.yml
@@ -22,10 +22,10 @@ runs:
 #      with:
 #        ref: ${{ github.event.deployment.ref }}
 #        lfs: true
-    - run: echo "${{ inputs.commenter_input }}" >> tf.out
+    - run: echo '${{ inputs.commenter_input }}' >> tf.out
       shell: bash
       name: Write terraform output to file
-    - run: cp "${{ github.event_path }}" event.json
+    - run: cp '${{ github.event_path }}' event.json
       shell: bash
       name: Copy event json to file
     - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ runs:
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT \
         -e COMMENTER_INPUT \
+        -e AWS_ACCESS_KEY_ID \
+        -e AWS_SECRET_ACCESS_KEY \
+        -e AWS_REGION \
         -v "$(pwd)"/:/workspace \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
@@ -52,6 +55,9 @@ runs:
         -e HIGHLIGHT_CHANGES \
         -e GITHUB_EVENT \
         -e COMMENTER_INPUT \
+        -e AWS_ACCESS_KEY_ID \
+        -e AWS_SECRET_ACCESS_KEY \
+        -e AWS_REGION \
         commenter ${{ inputs.commenter_type }} nop ${{ inputs.commenter_exitcode }}
       shell: bash
       if: ${{ inputs.commenter_type != 'plan' }}

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ runs:
     - run: echo ${{ inputs.commenter_input }} >> tf.out
       shell: bash
       name: Write terraform output to file
-    - run: docker build -t commenter -f Dockerfile .
+    - run: docker build -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#use-intermediate-file
       shell: bash
       name: Build commenter docker image
     - run: docker run -it -v local ${{ inputs.commenter_type }} tf.out ${{ inputs.commenter_exitcode }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,10 @@ fi
 # Arg 1 is command
 COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
-RAW_INPUT=$(<"$2")
+RAW_INPUT=""
+if test -f "$2"; then
+  RAW_INPUT=$(<"$2")
+fi
 INPUT=$(echo "RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,9 +31,11 @@ fi
 COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
 RAW_INPUT="$COMMENTER_INPUT"
-if test -f "/tfplan"; then
+if test -f "/workspace/tfplan"; then
   echo -e "Found tfplan; showing."
-  RAW_INPUT="$( terraform show "/tfplan" 2>&1 )"
+  pushd "/workspace"
+  RAW_INPUT="$( terraform show "tfplan" 2>&1 )"
+  popd
   echo -e "Plan raw input: $RAW_INPUT"
 else
   echo -e "Found no tfplan.  Proceeding with input argument."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ RAW_INPUT="$COMMENTER_INPUT"
 if test -f "/tfplan"; then
   echo -e "Found tfplan; showing."
   RAW_INPUT="$( terraform show "/tfplan" 2>&1 )"
+  echo -e "Plan raw input: $RAW_INPUT"
 else
   echo -e "Found no tfplan.  Proceeding with input argument."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ if [[ ! "$1" =~ ^(fmt|init|plan|validate)$ ]]; then
   exit 1
 fi
 
-echo -e "AWS region is: $AWS_REGION"
+echo -e "Environment is: $(env)"
 
 ##################
 # Shared Variables

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,7 @@
 #############
 # Validations
 #############
-GITHUB_EVENT_PATH=event.json
-PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+PR_NUMBER=$(echo "$GITHUB_EVENT" | jq -r ".pull_request.number")
 if [[ "$PR_NUMBER" == "null" ]]; then
 	echo "This isn't a PR."
 	exit 0
@@ -56,8 +55,8 @@ ACCEPT_HEADER="Accept: application/vnd.github.v3+json"
 AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
 CONTENT_HEADER="Content-Type: application/json"
 
-PR_COMMENTS_URL=$(jq -r ".pull_request.comments_url" "$GITHUB_EVENT_PATH")
-PR_COMMENT_URI=$(jq -r ".repository.issue_comment_url" "$GITHUB_EVENT_PATH" | sed "s|{/number}||g")
+PR_COMMENTS_URL=$(echo "$GITHUB_EVENT" | jq -r ".pull_request.comments_url")
+PR_COMMENT_URI=$(echo "$GITHUB_EVENT" | jq -r ".repository.issue_comment_url" | sed "s|{/number}||g")
 
 ##############
 # Handler: fmt

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,8 +24,6 @@ if [[ ! "$1" =~ ^(fmt|init|plan|validate)$ ]]; then
   exit 1
 fi
 
-echo -e "Environment is: $(env)"
-
 ##################
 # Shared Variables
 ##################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,11 +30,11 @@ fi
 # Arg 1 is command
 COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
-RAW_INPUT=""
-if test -f "$2"; then
-  RAW_INPUT="$(<"$2")"
-fi
-INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
+#RAW_INPUT="$COMMENTER_INPUT"
+#if test -f "$2"; then
+#  RAW_INPUT="$(<"$2")"
+#fi
+INPUT=$(echo "COMMENTER_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ COMMAND=$1
 RAW_INPUT="$COMMENTER_INPUT"
 if test -f "/tfplan"; then
   echo -e "Found tfplan; showing."
-  RAW_INPUT="$( { terraform show "/tfplan"; } 2>&1 )"
+  RAW_INPUT="$( terraform show "/tfplan" 2>&1 )"
 else
   echo -e "Found no tfplan.  Proceeding with input argument."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,13 +31,11 @@ fi
 COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
 RAW_INPUT="$COMMENTER_INPUT"
-if test -f "$COMMENTER_INPUT"; then
-  echo -e "Found a file matching $COMMENTER_INPUT; showing plan."
-  RAW_INPUT="$( { terraform show "$COMMENTER_INPUT"; } 2>&1 )"
+if [[ -d "/tfplan" ]] ; then
+  echo -e "Found no tfplan.  Proceeding with input argument."
 else
-  echo -e "No file matching $COMMENTER_INPUT; not showing plan."
-  echo -e "Directory contents: $(ls -la)"
-
+  echo -e "Found tfplan; showing."
+  RAW_INPUT="$( { terraform show "/tfplan"; } 2>&1 )"
 fi
 INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,8 @@
 #############
 # Validations
 #############
-PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
+GITHUB_EVENT=event.json
+PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT")
 if [[ "$PR_NUMBER" == "null" ]]; then
 	echo "This isn't a PR."
 	exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,8 +3,8 @@
 #############
 # Validations
 #############
-GITHUB_EVENT=event.json
-PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT")
+GITHUB_EVENT_PATH=event.json
+PR_NUMBER=$(jq -r ".pull_request.number" "$GITHUB_EVENT_PATH")
 if [[ "$PR_NUMBER" == "null" ]]; then
 	echo "This isn't a PR."
 	exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,9 @@ fi
 ##################
 # Arg 1 is command
 COMMAND=$1
-# Arg 2 is input. We strip ANSI colours.
-INPUT=$(echo "$2" | sed 's/\x1b\[[0-9;]*m//g')
+# Arg 2 is input file. We strip ANSI colours.
+RAW_INPUT=$(<"$2")
+INPUT=$(echo "RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,12 @@ COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
 RAW_INPUT="$COMMENTER_INPUT"
 if test -f "$COMMENTER_INPUT"; then
+  echo -e "Found a file matching $COMMENTER_INPUT; showing plan."
   RAW_INPUT="$( { terraform show "$COMMENTER_INPUT"; } 2>&1 )"
+else
+  echo -e "No file matching $COMMENTER_INPUT; not showing plan."
+  echo -e "Directory contents: $(ls -la)"
+
 fi
 INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,8 @@ if [[ ! "$1" =~ ^(fmt|init|plan|validate)$ ]]; then
   exit 1
 fi
 
+echo -e "AWS region is: $AWS_REGION"
+
 ##################
 # Shared Variables
 ##################

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,11 +31,11 @@ fi
 COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
 RAW_INPUT="$COMMENTER_INPUT"
-if [[ -d "/tfplan" ]] ; then
-  echo -e "Found no tfplan.  Proceeding with input argument."
-else
+if test -f "/tfplan"; then
   echo -e "Found tfplan; showing."
   RAW_INPUT="$( { terraform show "/tfplan"; } 2>&1 )"
+else
+  echo -e "Found no tfplan.  Proceeding with input argument."
 fi
 INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,11 +30,11 @@ fi
 # Arg 1 is command
 COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
-#RAW_INPUT="$COMMENTER_INPUT"
-#if test -f "$2"; then
-#  RAW_INPUT="$(<"$2")"
-#fi
-INPUT=$(echo "COMMENTER_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
+RAW_INPUT="$COMMENTER_INPUT"
+if test -f "$COMMENTER_INPUT"; then
+  RAW_INPUT="$( { terraform show "$COMMENTER_INPUT"; } 2>&1 )"
+fi
+INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,7 @@ COMMAND=$1
 # Arg 2 is input file. We strip ANSI colours.
 RAW_INPUT=""
 if test -f "$2"; then
-  RAW_INPUT=$(<"$2")
+  RAW_INPUT="$(<"$2")"
 fi
 INPUT=$(echo "RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ if test -f "/workspace/tfplan"; then
   pushd "/workspace"
   RAW_INPUT="$( terraform show "tfplan" 2>&1 )"
   popd
-  echo -e "Plan raw input: $RAW_INPUT"
+  # echo -e "Plan raw input: $RAW_INPUT"
 else
   echo -e "Found no tfplan.  Proceeding with input argument."
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ RAW_INPUT=""
 if test -f "$2"; then
   RAW_INPUT="$(<"$2")"
 fi
-INPUT=$(echo "RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
+INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 


### PR DESCRIPTION
Work around 64k character limit in docker/bash commands by, in the case of a plan, taking a plan file as an input and internally doing a `terraform show`.

Not fixed yet:  split into multiple comments to work around github comment 64k limit.