### PR TITLE
Fix yaml diffs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Build commenter docker image
       # append branch with a pound (#) if developing.  e.g., `commenter.git#my-branch`
-      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#fix-yaml-diffs
+      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git
       shell: bash
     - name: Run commenter image (plan)
       env:

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - name: Build commenter docker image
       # append branch with a pound (#) if developing.  e.g., `commenter.git#my-branch`
-      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git
+      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#fix-yaml-diffs
       shell: bash
     - name: Run commenter image (plan)
       env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,11 @@ if test -f "/workspace/tfplan"; then
 else
   echo -e "Found no tfplan.  Proceeding with input argument."
 fi
-INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
+# change diff character '-' in red into a high unicode character \U1f605 (literally 😅)
+INPUT=$(echo "$RAW_INPUT" | sed "s/\x1b\[31m-\x1b\[0m/😅/g")
+INPUT=$(echo "$INPUT" | sed 's/\x1b\[[0-9;]*m//g')
+
+#INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 
@@ -216,7 +220,8 @@ if [[ $COMMAND == 'plan' ]]; then
       CURRENT_PLAN="${CURRENT_PLAN%$'\n'*}" # trim to the last newline
       PROCESSED_PLAN_LENGTH=$((PROCESSED_PLAN_LENGTH+${#CURRENT_PLAN})) # evaluate length of outbound comment and store
 
-      CURRENT_PLAN=$(echo "$CURRENT_PLAN" | sed -r 's/^([[:blank:]]*)([-+~])/\2\1/g') # Move any diff characters to start of line
+      # Move any diff characters to start of line and then swap our emoji back to a '-'
+      CURRENT_PLAN=$(echo "$CURRENT_PLAN" | sed -r 's/^([[:blank:]]*)([😅+~])/\2\1/g' | sed -r 's/^😅/-/')
       if [[ $COLOURISE == 'true' ]]; then
         CURRENT_PLAN=$(echo "$CURRENT_PLAN" | sed -r 's/^~/!/g') # Replace ~ with ! to colourise the diff in GitHub comments
       fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,11 +40,15 @@ if test -f "/workspace/tfplan"; then
 else
   echo -e "Found no tfplan.  Proceeding with input argument."
 fi
-# change diff character '-' in red into a high unicode character \U1f605 (literally 😅)
+
+# change diff character, a red '-', into a high unicode character \U1f605 (literally 😅)
+# this serves as an intermediate representation representing "diff removal line" as distinct from
+# a raw hyphen which could *also* indicate a yaml list entry.
 INPUT=$(echo "$RAW_INPUT" | sed "s/\x1b\[31m-\x1b\[0m/😅/g")
+
+# now remove all ANSI colors
 INPUT=$(echo "$INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 
-#INPUT=$(echo "$RAW_INPUT" | sed 's/\x1b\[[0-9;]*m//g')
 # Arg 3 is the Terraform CLI exit code
 EXIT_CODE=$3
 


### PR DESCRIPTION
Problem:  PR commenter treated all lines starting with a literal `-` to be equivalent, which conflated yaml lists with removed lines.  

Solution:  in the terraform output, the *color* of the `-` for diff-removal is ANSI red; for raw yaml it is un-colored.  Therefore, before we strip ANSI colors at the start, we change all *red* `-` to be an intermediate, not-likely-to-appear-in-terraform upper-unicode character (literally a unicode 😅 face).  We change it back after formatting the file as a diff.