### PR TITLE
fix: removing commenter_input validation as some commands dont have console output on successfull runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ env:
   GH_AUTH_HEADER: "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
   GH_API_VERSION: "X-GitHub-Api-Version: 2022-11-28"
   GH_COMMENT_URL: https://api.github.com/repos/GetTerminus/terraform-pr-commenter/issues/${{ github.event.number }}/comments
-  TESTING: "true" #set to false when finished testing
+  TESTING: "false" #set to false when finished testing
 
 jobs:
   set-outputs:
@@ -78,4 +78,4 @@ jobs:
           commenter_input: ${{ needs.set-outputs.outputs.tf_plan_success_with_outputs }}
           #commenter_plan_path: ./testing/text-files/tf_plan_success_with_outputs.txt
           commenter_exitcode: 2
-          use_beta_version: "false"
+          use_beta_version: "true"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ env:
   GH_AUTH_HEADER: "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
   GH_API_VERSION: "X-GitHub-Api-Version: 2022-11-28"
   GH_COMMENT_URL: https://api.github.com/repos/GetTerminus/terraform-pr-commenter/issues/${{ github.event.number }}/comments
-  TESTING: "false" #set to false when finished testing
+  TESTING: "true" #set to false when finished testing
 
 jobs:
   set-outputs:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,4 +78,4 @@ jobs:
           commenter_input: ${{ needs.set-outputs.outputs.tf_plan_success_with_outputs }}
           #commenter_plan_path: ./testing/text-files/tf_plan_success_with_outputs.txt
           commenter_exitcode: 2
-          use_beta_version: "true"
+          use_beta_version: "false"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ env:
   GH_AUTH_HEADER: "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}"
   GH_API_VERSION: "X-GitHub-Api-Version: 2022-11-28"
   GH_COMMENT_URL: https://api.github.com/repos/GetTerminus/terraform-pr-commenter/issues/${{ github.event.number }}/comments
-  TESTING: "true" #set to false when finished testing
+  TESTING: "false" #set to false when finished testing
 
 jobs:
   set-outputs:

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Build commenter docker image (master)
       if: ${{ inputs.use_beta_version != 'true' }}
-      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#master
+      run: docker build --build-arg TERRAFORM_VERSION=${{ inputs.terraform_version }} -t commenter https://github.com/GetTerminus/terraform-pr-commenter.git#v3
       shell: bash
     - name: Build commenter docker image (beta)
       if: ${{ inputs.use_beta_version == 'true' }}

--- a/utilities/input_validation_utility.sh
+++ b/utilities/input_validation_utility.sh
@@ -19,18 +19,4 @@ validate_inputs () {
     error "Unsupported command \"$1\". Valid commands are \"fmt\", \"init\", \"plan\", \"validate\", \"tflint\"."
     exit 1
   fi
-
-  if [[ $1 == "plan" ]]; then
-    if [[ -z "$COMMENTER_INPUT" ]]; then
-      if [[ -z "$COMMENTER_PLAN_FILE" ]]; then
-        error "The commenter_plan_path input variable must be set if commenter_input is empty."
-        exit 1
-      fi
-    fi
-  else
-    if [[ -z "$COMMENTER_INPUT" ]]; then
-      error "The commenter_input input variable must be set for non plan commenter types."
-      exit 1
-    fi
-  fi
 }


### PR DESCRIPTION
Also added tag to docker build so it isn't always building master.