### PR TITLE
Support multiple Terragrunt modules plan output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   commenter_exitcode:
     description: 'The exit code from a previous step output'
     required: true
+  multiple_modules:
+    description: 'Support multiple modules (do not cut off after first plan)'
+    required: false
+    default: 'false'
   terraform_version:
     description: 'The version of terraform from the workflow.'
     required: false
@@ -51,6 +55,7 @@ runs:
       if: ${{ inputs.commenter_type == 'plan' }}
       env:
         COMMENTER_INPUT: ${{ inputs.commenter_input }}
+        COMMENTER_MULTIPLE_MODULES: ${{ inputs.multiple_modules }}
         COMMENTER_PLAN_FILE: ${{ inputs.commenter_plan_path }}
         GITHUB_EVENT: ${{ toJSON(github.event) }}
       run: |
@@ -63,6 +68,7 @@ runs:
         -e COMMENTER_INPUT \
         -e COMMENTER_DEBUG \
         -e COMMENTER_ECHO \
+        -e COMMENTER_MULTIPLE_MODULES \
         -e COMMENTER_PLAN_FILE \
         -e COMMENTER_POST_PLAN_OUTPUTS \
         -v "$(pwd)"/:/workspace \

--- a/handlers/plan_handler.sh
+++ b/handlers/plan_handler.sh
@@ -60,7 +60,9 @@ post_plan_comments () {
   debug "delimiter_end_cmd: $delimiter_end_cmd"
 
   clean_input=$(echo "$INPUT" | perl -pe "${delimiter_start_cmd}")
-  clean_input=$(echo "$clean_input" | sed -r "${delimiter_end_cmd}")
+  if [[ $MULTIPLE_MODULES != 'true' ]]; then
+    clean_input=$(echo "$clean_input" | sed -r "${delimiter_end_cmd}")
+  fi
 
   post_diff_comments "plan" "Terraform \`plan\` Succeeded for Workspace: \`$WORKSPACE\`" "$clean_input"
 }

--- a/utilities/parse_args.sh
+++ b/utilities/parse_args.sh
@@ -58,6 +58,8 @@ parse_args () {
   # shellcheck disable=SC2034
   COLOURISE=${HIGHLIGHT_CHANGES:-true}
 
+  # support multiple-module plan outputs (e.g., when running Terragrunt)
+  MULTIPLE_MODULES=${COMMENTER_MULTIPLE_MODULES:-true}
   # Read COMMENTER_POST_PLAN_OUTPUTS environment variable or use "true"
   # shellcheck disable=SC2034
   POST_PLAN_OUTPUTS=${COMMENTER_POST_PLAN_OUTPUTS:-true}


### PR DESCRIPTION
Add an option to disable cutting off the rest of the plan after the first `Plan:` line. This adds a possibility of using this action with Terragrunt and/or multiple Terraform modules planned in parallel, including all plans in the comment.